### PR TITLE
Adding setuptools to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 [tool.poetry.dependencies]
 
 python = "^3.8.10"
-
+setuptools = "^69.0.0"
 pyyaml = "^6.0"
 markdown = "^3.3.3"
 bottle = "~0.12.25"


### PR DESCRIPTION
Adding setuptools dependency so setuptools doesn't have to be installed 'manually' in github workflow.