### PR TITLE
Update Template- GitLab

### DIFF
--- a/doorstop/core/files/templates/latex/doorstop.cls
+++ b/doorstop/core/files/templates/latex/doorstop.cls
@@ -224,7 +224,7 @@
 \fancyhf{}% Clear all settings
 \fancyhead[RE,RO]{\raisebox{0.5cm}{\textsf{\begin{tabular}{p{5cm}p{2.5cm}p{3.5cm}}
 \textbf{\large\docname} & {\footnotesize\textbf{Repository:}} &{\footnotesize\textbf{Workflow:}}\tabularnewline
-\multirow{3}{5cm}[1ex]{\textit{\docdef}}&\textrm{\small\repo} & \textrm{\small\gitBranch} \tabularnewline
+\multirow{3}{5cm}[1ex]{\textit{\docdef}}&\textrm{\small\gitlabrepo} & \textrm{\small\gitBranch} \tabularnewline
 &{\footnotesize\textbf{Date:}} & {\footnotesize\textbf{Commit:}}\tabularnewline
 &\textrm{\small\today} & \textrm{\small\gitDescribe} \tabularnewline
 \end{tabular}}}}

--- a/doorstop/core/files/templates/latex/doorstop.cls
+++ b/doorstop/core/files/templates/latex/doorstop.cls
@@ -130,8 +130,9 @@
 \definetrim{logotrim}{20pt 100pt 20pt 100pt}
 \def\titlelogo{template/title-logo.png}
 
-% Define the repository href format
-\def\repo{\href{\repourl}{GitHub Repo}}
+% Define the repositories href format
+\def\gitlabrepo{\href{\repourl}{GitLab Repo}}
+\def\githubrepo{\href{\githuburl}{GitHub Repo}}
 
 % Sets the counting depths for TOC
 \setcounter{tocdepth}{3}
@@ -222,7 +223,7 @@
 \pagestyle{fancy}
 \fancyhf{}% Clear all settings
 \fancyhead[RE,RO]{\raisebox{0.5cm}{\textsf{\begin{tabular}{p{5cm}p{2.5cm}p{3.5cm}}
-\textbf{\large\docname} & {\footnotesize\textbf{Repository:}} &{\footnotesize\textbf{Branch:}}\tabularnewline
+\textbf{\large\docname} & {\footnotesize\textbf{Repository:}} &{\footnotesize\textbf{Workflow:}}\tabularnewline
 \multirow{3}{5cm}[1ex]{\textit{\docdef}}&\textrm{\small\repo} & \textrm{\small\gitBranch} \tabularnewline
 &{\footnotesize\textbf{Date:}} & {\footnotesize\textbf{Commit:}}\tabularnewline
 &\textrm{\small\today} & \textrm{\small\gitDescribe} \tabularnewline
@@ -293,8 +294,9 @@
      		{\Huge \textbf{\doctitle\\[0.5cm]}}
      		{\LARGE \textit{\docdef}}\\[0.5cm]
             {\large \textbf{Date: }\today} \vfill
-            {\large \textbf{\repo}} \\[0.2cm]
-			{\large \textbf{Branch: } \gitBranch}
+            {\large \textbf{\gitlabrepo} \textit{- Full Requirements Generation Repository}}\\[0.2cm]
+            {\large \textbf{\githubrepo} \textit{- Levels 0-3 Requirements Repository}}\\[0.2cm]
+			{\large \textbf{Workflow: } \gitBranch}
 			{\large \textbf{ Commit:} \gitDescribe} \vfill
 			{\small \textbf{Authors: } \authors} \\[0.2cm]
             {\small \textbf{Contributors: } \contributors} \vfill

--- a/doorstop/core/files/templates/latex/doorstop.yml
+++ b/doorstop/core/files/templates/latex/doorstop.yml
@@ -34,7 +34,8 @@ before_begin_document:
   # Define the title for the published document output
   - \def\docname{Pearl Requirements}
   # Define / update the repository link requirements are located for reference
-  - \def\repourl{https://github.com/uasal/pearl_requirements}
+  - \def\repourl{https://gitlab.sc.ascendingnode.tech/pearl-systems/pearl_requirements}
+  - \def\githuburl{https://github.com/uasal/pearl_requirements}
   - \def\access{For access to the repository contact douglase@arizona.edu}
   # Define the 'subtitle' that will be listed under the title.
   - \def\docdef{Descriptions, Owners, Rationales, and Notes}

--- a/doorstop/core/publishers/base.py
+++ b/doorstop/core/publishers/base.py
@@ -317,7 +317,7 @@ def get_document_attributes(obj, is_html=False, extensions=None):
     doc_attributes = {}
     doc_attributes["name"] = "doc-" + obj.prefix
     doc_attributes["title"] = "Pearl Requirements"
-    doc_attributes["ref"] = "GitHub"
+    doc_attributes["ref"] = "GitLab"
     doc_attributes["by"] = "-"
     doc_attributes["major"] = "-"
     doc_attributes["minor"] = ""


### PR DESCRIPTION
`U/sfrinaldi/gitlab` template edits. Updates '_GitHub_' mention to be _GitLab_ and correct url default. Includes mentions and links to both _GitHub_ and _GitLab_ repositories for information. Changed branch to be `workflow` to better represent what is referenced / pulled for _GitLab_ pipelines but still be applicable.  This impacts the display for the title page and the page headers for the output requirements pdf.

**Example of Template Adjustments:**
![image](https://github.com/user-attachments/assets/5bb9d721-6309-4b16-9718-064d30e7c5ee)
![image](https://github.com/user-attachments/assets/77c9655b-1266-4e56-9e89-abcfa9a1b078)

Tested output of branch changes for requirements on a gitlab fork / pipeline runs. Updating main branch on here for current up to date branches on Github to grab from and GitLab branches to be merged. 

If out of date branches on GitHub/GitLab repositories are okay to have failing workflows, can edit this PR to merge into develop first _**after**_ updating the develop branch on here (which has an older version of doorstop). 

