### PR TITLE
u/sfrinaldi/template-header-fix

### DIFF
--- a/doorstop/core/files/templates/latex/doorstop.cls
+++ b/doorstop/core/files/templates/latex/doorstop.cls
@@ -73,7 +73,7 @@
 \RequirePackage{xstring}
 \RequirePackage[compact]{titlesec}
 \RequirePackage{appendix}
-\RequirePackage[ddmmyyyy]{datetime}
+\RequirePackage[yyyymmdd]{datetime}
 % The following packages are REQUIRED to make the Doorstop publish functions work.
 \RequirePackage{amsmath}
 \RequirePackage{ulem}

--- a/doorstop/core/files/templates/latex/doorstop.cls
+++ b/doorstop/core/files/templates/latex/doorstop.cls
@@ -73,6 +73,7 @@
 \RequirePackage{xstring}
 \RequirePackage[compact]{titlesec}
 \RequirePackage{appendix}
+\RequirePackage[ddmmyyyy]{datetime}
 % The following packages are REQUIRED to make the Doorstop publish functions work.
 \RequirePackage{amsmath}
 \RequirePackage{ulem}

--- a/doorstop/core/files/templates/latex/doorstop.yml
+++ b/doorstop/core/files/templates/latex/doorstop.yml
@@ -13,6 +13,8 @@ usepackage:
   ragged2e:
   tabularx:
   longtable:
+  datetime:
+    - ddmmyyyy
   lastpage:
   fancyvrb:
   textalpha:

--- a/doorstop/core/files/templates/latex/doorstop.yml
+++ b/doorstop/core/files/templates/latex/doorstop.yml
@@ -14,7 +14,7 @@ usepackage:
   tabularx:
   longtable:
   datetime:
-    - ddmmyyyy
+    - yyyymmdd
   lastpage:
   fancyvrb:
   textalpha:


### PR DESCRIPTION
To shorten date (can change the format if desired) to limit overflow in header with full date in current latex template. Fixes workflow for pearl_requirements with current template (longer date for header in full format right now).

**New Format:** _DDMMYYYY_ ex.) _04/09/2024_

**Previous Format:** _ex.) September 09, 2024_

Let me know if another date format is prefer before merging. (Small change)