### PR TITLE
fix: #11 u/sfrinaldi/md-html-fix

### DIFF
--- a/doorstop/core/files/templates/html/doorstop.css
+++ b/doorstop/core/files/templates/html/doorstop.css
@@ -5,3 +5,10 @@
     }
 
 #img {width: 100%}
+
+.anchor{
+    display:block;
+    height:163px; /* this is the height of your header */
+    margin-top:-163px; /* this is again negative value of the height of your header */
+    visibility:hidden;  
+}

--- a/doorstop/core/publishers/base.py
+++ b/doorstop/core/publishers/base.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 
 from markdown import markdown
 
-from doorstop import common
+from doorstop import common, settings
 from doorstop.common import DoorstopError
 from doorstop.core.template import get_template
 from doorstop.core.types import is_tree
@@ -315,9 +315,9 @@ def format_level(level):
 def get_document_attributes(obj, is_html=False, extensions=None):
     """Try to get attributes from document."""
     doc_attributes = {}
-    doc_attributes["name"] = "doc-" + obj.prefix
-    doc_attributes["title"] = "Pearl Requirements"
-    doc_attributes["ref"] = "GitLab"
+    doc_attributes["name"] = "Doc-" + obj.prefix
+    doc_attributes["title"] = settings.PROJECT
+    doc_attributes["ref"] = settings.DOC_REPO
     doc_attributes["by"] = "-"
     doc_attributes["major"] = "-"
     doc_attributes["minor"] = ""

--- a/doorstop/core/publishers/html.py
+++ b/doorstop/core/publishers/html.py
@@ -103,7 +103,7 @@ class HtmlPublisher(MarkdownPublisher):
                 "\n".join(lines),
                 doc_attributes={
                     "name": "Index",
-                    "ref": "https://github.com/uasal/pearl_requirements",
+                    "repo": settings.DOC_REPO,
                     "title": "Requirements Index",
                     "by": "-",
                     "major": "-",
@@ -177,7 +177,7 @@ class HtmlPublisher(MarkdownPublisher):
             "\n".join(lines),
             doc_attributes={
                 "name": "Traceability",
-                "ref": "-",
+                "repo": settings.DOC_REPO,
                 "title": "Requirements Traceability Matrix",
                 "by": "-",
                 "major": "-",
@@ -193,6 +193,7 @@ class HtmlPublisher(MarkdownPublisher):
         doc_attributes,
         toc=None,
         parent=None,
+        child=None,
         document=None,
         is_doc=False,
         has_index=False,
@@ -207,6 +208,7 @@ class HtmlPublisher(MarkdownPublisher):
             body=body,
             toc=toc,
             parent=parent,
+            child=child,
             document=document,
             doc_attributes=doc_attributes,
             is_doc=is_doc,
@@ -261,8 +263,8 @@ class HtmlPublisher(MarkdownPublisher):
                     u=item.uid, h=item.header, p=item.document.prefix, r=tmpRef
                 )
             else:
-                link = '<a href="{r}{p}.html#{u}">{u}</a>'.format(
-                    u=item.uid, p=item.document.prefix, r=tmpRef
+                link = '<a href="{r}{p}.html#{u}-{s}">{u}</a>'.format(
+                    u=item.uid, p=item.document.prefix, s=item.short_name, r=tmpRef
                 )
             return link
         else:
@@ -337,6 +339,7 @@ class HtmlPublisher(MarkdownPublisher):
                 doc_attributes,
                 toc=toc_html,
                 parent=obj.parent,
+                child = obj.children,
                 document=obj,
                 is_doc=True,
                 has_index=self.getIndex(),
@@ -360,14 +363,14 @@ class HtmlPublisher(MarkdownPublisher):
             elif item.header:
                 heading = "{h}".format(h=item.header)
             else:
-                heading = item.uid
+                heading = "{u}-{s}".format(u=item.uid,s=item.short_name)
             if settings.PUBLISH_HEADING_LEVELS:
                 level = format_level(item.level)
                 lbl = "{lev} {h}".format(lev=level, h=heading)
             else:
                 lbl = heading
             if linkify:
-                uid = item.uid
+                uid = "{u}-{s}".format(u=item.uid,s=item.short_name)
             else:
                 uid = ""
             toc.append({"depth": item.depth, "text": lbl, "uid": uid})

--- a/doorstop/core/publishers/html.py
+++ b/doorstop/core/publishers/html.py
@@ -103,7 +103,7 @@ class HtmlPublisher(MarkdownPublisher):
                 "\n".join(lines),
                 doc_attributes={
                     "name": "Index",
-                    "repo": settings.DOC_REPO,
+                    "ref": settings.DOC_REPO,
                     "title": "Requirements Index",
                     "by": "-",
                     "major": "-",
@@ -177,7 +177,7 @@ class HtmlPublisher(MarkdownPublisher):
             "\n".join(lines),
             doc_attributes={
                 "name": "Traceability",
-                "repo": settings.DOC_REPO,
+                "ref": settings.DOC_REPO,
                 "title": "Requirements Traceability Matrix",
                 "by": "-",
                 "major": "-",

--- a/doorstop/core/publishers/latex.py
+++ b/doorstop/core/publishers/latex.py
@@ -212,22 +212,24 @@ class LaTeXPublisher(BasePublisher):
                     #yield ""  # break before reference
                     yield self.format_references(item)
 
-                # Parent and Child links
-                if settings.PUBLISH_CHILD_LINKS:
-                    items2 = item.find_child_items()
-                    label_links = ""
-                    if item.links or items2:
-                        if item.links:
-                            items1 = item.parent_items
-                            label = "Parent links:"
-                            links = self.format_links(items1, linkify)
-                            label_links = self.format_label_links(label, links, linkify)
-                        if items2:
-                            label = "Child links:"
-                            links = self.format_links(items2, linkify)
-                            label_links = self.format_label_links(label, links, linkify)
-                        yield label_links
-
+            # Parent Links
+            if item.links:
+                items1 = item.parent_items
+                if items1 and settings.PUBLISH_PARENT_LINKS:
+                    label = "Parent Links:"
+                    links = self.format_links(items1, linkify)
+                    label_links = self.format_label_links(label, links, linkify)
+                    yield label_links + "\n"
+                    
+            # Child Links
+            if settings.PUBLISH_CHILD_LINKS:
+                items2 = item.find_child_items()
+                if items2:
+                    label = "Child Links:"
+                    links = self.format_links(items2, linkify)
+                    label_links = self.format_label_links(label, links, linkify)
+                    yield label_links + "\n"
+                    
                 # Original version
                 # if item.document and item.document.publish:
                 #     header_printed = False

--- a/doorstop/core/publishers/markdown.py
+++ b/doorstop/core/publishers/markdown.py
@@ -231,8 +231,11 @@ class MarkdownPublisher(BasePublisher):
         else:
             uid = item.uid
             if settings.ENABLE_HEADERS:
+                #<span class="anchor" id="L3-0024-Payload Metrology"></span><div id="L3-0024-Payload Metrology"></div>
                 if to_html:
-                    uid = "{u}-<small><i>{s}</i></small>".format(u=item.uid, s=item.short_name)
+                    header = "{u}-<small><i>{s}</i></small>".format(u=item.uid, s=item.short_name)
+                    span = "<span class='anchor' id='{u}-{s}'></span><div id='{u}-{s}'></div>".format(u=item.uid, s=item.short_name)
+                    uid = span + header
                 else:
                     uid = "{u}- _{s}_".format(u=item.uid, s=item.short_name)
             else:

--- a/doorstop/core/publishers/markdown.py
+++ b/doorstop/core/publishers/markdown.py
@@ -273,7 +273,6 @@ class MarkdownPublisher(BasePublisher):
             uid = str(item.uid)
             split_uid = uid.split("-")
             label_links = ""
-            items2 = item.find_child_items()
 
             # 'Level' Header for each document w/separator
             if item_count == 0:
@@ -326,17 +325,18 @@ class MarkdownPublisher(BasePublisher):
                 yield ""  # break before reference
                 yield self.format_references(item)
 
-            # Parent links
-            if settings.PUBLISH_PARENT_LINKS:
-                if item.links:
-                    items1 = item.parent_items
+            # Parent Links
+            if item.links:
+                items1 = item.parent_items
+                if items1 and settings.PUBLISH_PARENT_LINKS:
                     label = "Parent Links:"
                     links = self.format_links(items1, linkify)
                     label_links = self.format_label_links(label, links, linkify)
                     yield label_links + "\n"
-
-            # Child links
+                    
+            # Child Links
             if settings.PUBLISH_CHILD_LINKS:
+                items2 = item.find_child_items()
                 if items2:
                     label = "Child Links:"
                     links = self.format_links(items2, linkify)

--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -53,6 +53,9 @@ PUBLISH_HEADING_LEVELS = False  # include levels on header items
 ENABLE_HEADERS = True  # use headers if defined
 WRITE_LINESEPERATOR = os.linesep
 
+# Document settings
+DOC_REPO = '<a href="https://gitlab.sc.ascendingnode.tech:8443/pearl-systems/pearl_requirements">GitLab</a>
+
 # Version control settings
 ADDREMOVE_FILES = True  # automatically add/remove new/changed files
 
@@ -64,3 +67,4 @@ CACHE_PATHS = True  # cache file/directory paths and contents
 # Server settings
 SERVER_HOST = None  # '' = server not specified, None = no server in use
 SERVER_PORT = 7867
+

--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -46,6 +46,7 @@ REVIEW_NEW_ITEMS = True  # automatically review new items during validation
 STAMP_NEW_LINKS = True  # automatically stamp links upon creation
 
 # Publishing settings
+PUBLISH_PARENT_LINKS = True # include parent links when publishing
 PUBLISH_CHILD_LINKS = True  # include child links when publishing
 PUBLISH_BODY_LEVELS = False  # include levels on non-header items
 PUBLISH_HEADING_LEVELS = False  # include levels on header items

--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -54,7 +54,8 @@ ENABLE_HEADERS = True  # use headers if defined
 WRITE_LINESEPERATOR = os.linesep
 
 # Document settings
-DOC_REPO = '<a href="https://gitlab.sc.ascendingnode.tech:8443/pearl-systems/pearl_requirements">GitLab</a>
+DOC_REPO = "https://gitlab.sc.ascendingnode.tech:8443/pearl-systems/pearl_requirements"
+PROJECT = 'Pearl Requirements'
 
 # Version control settings
 ADDREMOVE_FILES = True  # automatically add/remove new/changed files

--- a/doorstop/views/base.tpl
+++ b/doorstop/views/base.tpl
@@ -1,5 +1,5 @@
 %setdefault('stylesheet', None)
-%setdefault('navigation', False)
+%setdefault('navigation', True)
 <!DOCTYPE html>
 <html>
 <head><title>{{!doc_attributes["name"]}}</title>
@@ -21,7 +21,7 @@
   </script>
 </head>
 <body>
-{{! '<P>Navigation: <a href="{0}">Home</a> &bull; <a href="{0}documents/">Documents</a>'.format(baseurl) if navigation else ''}}
+{{! '<P><strong>Navigation: </strong><a href="{0}">Home</a> &bull; <a href="{0}documents/">Documents</a>'.format(baseurl) if navigation else ''}}
   {{!base}}
 </body>
 </html>

--- a/doorstop/views/document_list.tpl
+++ b/doorstop/views/document_list.tpl
@@ -1,5 +1,5 @@
 % rebase('base.tpl')
-<H1>Doorstop - List of documents</H1>
+<H1>Doorstop - List of Requirement Documents</H1>
 <P>
 <ul>
 {{! "".join('<li><a href="{0}">{0}</a></li>'.format(p) for p in prefixes) }}

--- a/doorstop/views/doorstop.tpl
+++ b/doorstop/views/doorstop.tpl
@@ -60,16 +60,14 @@
           </div>
         </div>
         <div class="col-2">
-          <div class="bd-lead text-nowrap">
-            <span class="text-muted">Ref</span>
-            <p><span class="text-monospace">{{doc_attributes["ref"]}}</span></p>
+          <div class="bd-text-nowrap text-center">
+            <span class="text-muted"><strong>Repo</strong></span>
+            <p><span class="text-monospace"><a href={{doc_attributes["ref"]}}>GitLab</a></span></p>
           </div>
         </div>
         <div class="col-2">
           <div class="bd-lead text-nowrap">
-            <span class="text-muted">By</span>
-            <p><span class="text-monospace">{{doc_attributes["by"]}}</span></p>
-            <span class="text-muted">Issue</span>
+            <span class="text-muted"><strong>Commit</strong></span>
             <p><span class="text-monospace">{{doc_attributes["major"]}}{{doc_attributes["minor"]}}</span></p>
           </div>
         </div>


### PR DESCRIPTION
Fixes a markdown, html, and latex link issue for parent and child links not fully publishing to output documents. 

Noticed recently some requirements are not fully linking to markdown documentation mainly but also impacts latex outputs as well. HTML output is a sub-class of markdown so fixes apply to both.